### PR TITLE
config in environment variables

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,21 +4,22 @@ from app.utils.environment import Environment
 class Config:
     DEBUG = True
     TESTING = False
-    LOG_LEVEL = 'DEBUG'
-    # DB_HOST = 'localhost'
-    # DB_NAME = 'test'
-    # DB_USER = 'root'
-    # DB_PASS = 'root'
+    LOG_LEVEL = os.getenv('LOG_LEVEL', 'DEBUG')
+    DB_HOST = os.getenv('DB_HOST', 'localhost')
+    DB_PORT = os.getenv('DB_PORT', 3306)
+    DB_NAME = os.getenv('DB_NAME', 'test')
+    DB_USER = os.getenv('DB_USER', 'root')
+    DB_PASS = os.getenv('DB_PASS', 'root')
     # BACKUP_PATH = '/var/backup/ehome/'
     # UPLOAD_PATH = '/srv/http/ehome/app/frontend/planos'
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
     SQLALCHEMY_TRACK_MODIFICATIONS = True
-    SECRET_KEY = "sarakatunga katunga katunga todos queremos sarakatunga"
+    SECRET_KEY = os.getenv('SECRET_KEY', 'sarakatunga katunga katunga todos queremos sarakatunga')
 
 
 class ProductionConfig(Config):
     LOG_LEVEL = 'WARNING'
-    SQLALCHEMY_DATABASE_URI = 'mysql://root@localhost:3306/stock.ar'
+    SQLALCHEMY_DATABASE_URI = 'mysql://%s:%s@%s:%d/%s' % (DB_USER, DB_PASS, DB_HOST, DB_PORT, DB_NAME)
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+PORT=${API_PORT:-5000}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 cd "$DIR"
 VENV_DIR=../venv
@@ -10,4 +11,4 @@ printf "===> Attempting to run stock.ar\n\n"
 source ../venv/bin/activate
 export FLASK_ENV=development
 export FLASK_APP=run.py
-flask run
+flask run --port "$PORT"


### PR DESCRIPTION
Env vars are easy to change between deploys without changing any code; unlike config files, there is little chance of them being checked into the code repo accidentally; and unlike custom config files, or other config mechanisms such as Java System Properties, they are a language- and OS-agnostic standard.